### PR TITLE
Update service location

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>edu.stanford.protege</groupId>
 	<artifactId>oops</artifactId>
-	<version>1.0.1</version>
+	<version>1.0.2</version>
 	<packaging>bundle</packaging>
 
 	<name>OOPS! Evaluator</name>

--- a/src/main/java/oops/evaluation/OOPSEvaluator.java
+++ b/src/main/java/oops/evaluation/OOPSEvaluator.java
@@ -44,7 +44,7 @@ public class OOPSEvaluator {
     
     private static final Logger logger = LoggerFactory.getLogger(OOPSEvaluator.class);
     
-    private static final String OOPS_WS_ENDPOINT = "http://oops-ws.oeg-upm.net/rest";
+    private static final String OOPS_WS_ENDPOINT = "http://oops.linkeddata.es/rest";
     
     private static final String OOPS_WS_REQUEST_TEMPLATE = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
     		+ "<OOPSRequest>"

--- a/update.properties
+++ b/update.properties
@@ -1,7 +1,7 @@
 id=oops
-version=1.0.1
-download=https://github.com/lukasged/oops-plugin/releases/download/v1.0.1/oops-1.0.1.jar?raw=true
+version=1.0.2
+download=https://github.com/lukasged/oops-plugin/releases/download/v1.0.2/oops-1.0.2.jar?raw=true
 name=OOPS! Evaluator
 readme=https://raw.githubusercontent.com/lukasged/oops-plugin/master/version-info.html
 license=https://opensource.org/licenses/gpl-3.0.html
-author=Lukas Gedvilas, Universidad Politécnica de Madrid
+author=Lukas Gedvilas, Universidad PolitÃ©cnica de Madrid


### PR DESCRIPTION
The OOPS rest service URL has changed. This patch updates the plugin to reflect that change.

I took the liberty to bump the minor software version up to 1.0.2 to reflect the change.